### PR TITLE
Update SchemaState Process to remove timeout

### DIFF
--- a/src/Illuminate/Database/Schema/SchemaState.php
+++ b/src/Illuminate/Database/Schema/SchemaState.php
@@ -58,7 +58,7 @@ abstract class SchemaState
         $this->files = $files ?: new Filesystem;
 
         $this->processFactory = $processFactory ?: function (...$arguments) {
-            return Process::fromShellCommandline(...$arguments);
+            return Process::fromShellCommandline(...$arguments)->setTimeout(null);
         };
 
         $this->handleOutputUsing(function () {


### PR DESCRIPTION
### Issue Description:
"Dumper" (pg_dump/ pg_restore) migrations can timeout on slow machines, or when dumps are fairly decent in size.

### Proposed Solution
Remove the timeout for long lived processes such as pg_restore.

Default timeout is 60s, Symphony Process docs: https://symfony.com/doc/current/components/process.html#process-timeout

I didn't include any tests as it doesn't seem like this would need it.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
